### PR TITLE
about.md: unbreak the paper link on main page using the redirect

### DIFF
--- a/_pages/about.md
+++ b/_pages/about.md
@@ -12,4 +12,4 @@ social: true  # includes social icons at the bottom of the page
 The Languini Kitchen is a research collective and codebase designed to empower researchers with limited computational resources to contribute meaningfully to language modelling research. 
 Our academic [code](https://github.com/languini-kitchen/languini-kitchen) is performant, easy to use, and hackable, and we invite you to share your innovations and checkpoints in order to facilitate reproducibility and fair comparisons.
 The second goal of Languini is to identify better methods that scale. To this end, methods and models on Languini are compared by their scaling laws on a large high-quality dataset with long-dependencies --- ideal for language modelling research in the underfitting regime. 
-For further details please read our [paper](https://arxiv.org/).
+For further details please read our [paper](/paper/).


### PR DESCRIPTION
A broken link is contained in the page body. This uses a redirect established in https://github.com/languini-kitchen/languini-kitchen.github.io/commit/7dc41532a294fcb4fdae33fcc73d62f75276aee5


This has the same effect as #1 but using the redirect.